### PR TITLE
feat(n8n): allow fs,path for Reelsmith Code nodes

### DIFF
--- a/helm/n8n-application/values-live.yaml
+++ b/helm/n8n-application/values-live.yaml
@@ -89,6 +89,13 @@ extraEnv:
         name: reelsmith-telegram
         key: chat_id
         optional: true
+  # n8n 2.x task-runner sandbox blocks node built-ins by default.
+  # Reelsmith Code nodes (Index Clips / Scan Manifests / Log Results / Archive
+  # Manifest) require fs + path to read manifest CSVs, walk the inbox, append
+  # log rows, and rename to processed/. Without these, every execution errors
+  # with "Module 'fs' is disallowed".
+  - name: NODE_FUNCTION_ALLOW_BUILTIN
+    value: "fs,path"
 
 autoscaling:
   enabled: false  # LIVE: Single-node, no autoscaling


### PR DESCRIPTION
## Summary

n8n 2.x ships `@n8n/task-runner` with a sandboxed Code-node executor that blocks node built-ins by default. Reelsmith's Code nodes (Index Clips, Scan Manifests, Log Results, Archive Manifest) all require `fs` + `path` to read manifest CSVs, walk `/data/reelsmith-inbox`, append `results.log.csv`, and rename consumed manifests to `processed/`.

Without this env, every execution fails with `Module 'fs' is disallowed [line 1]` before any work happens (verified live: execution 325 errored at `Scan Manifests`).

Adds `NODE_FUNCTION_ALLOW_BUILTIN=fs,path` to the existing `extraEnv` block in `values-live.yaml`. Allow-list is intentionally narrow — only the two built-ins Reelsmith needs.

## Verification

- `helm template ... values-live.yaml` renders the env into BOTH `n8n` Deployment and `n8n-application-worker` Deployment (top-level `extraEnv` is referenced by both templates).
- Linked to P0 'first published reel' block 2026-05-08.

## Test plan

- [ ] ArgoCD auto-sync picks up the change.
- [ ] Workers restart with the new env (`kubectl exec ... env | grep NODE_FUNCTION`).
- [ ] Reelsmith workflow execution succeeds end-to-end via Scanner Trigger.
- [ ] Telegram delivery confirmed.

## Scope of risk

Allow-list is fs + path only. Does not touch `NODE_FUNCTION_ALLOW_EXTERNAL` (npm modules) — those remain disallowed.