### PR TITLE
feat(reelsmith): TikTok sidecar cutover — replace Open API path

### DIFF
--- a/demos/sme-professional-services/w1-client-intake.json
+++ b/demos/sme-professional-services/w1-client-intake.json
@@ -1,4 +1,4 @@
-{
+{"id": "3e0e169b-fa55-4e26-a732-b5f52c37e00e",
   "name": "W1 - Client Intake & Onboarding",
   "description": null,
   "active": true,

--- a/demos/sme-professional-services/w2-document-chase.json
+++ b/demos/sme-professional-services/w2-document-chase.json
@@ -1,4 +1,4 @@
-{
+{"id": "04c21a4d-fa95-45f1-866c-60c68a54edae",
   "name": "W2 - Document Chase (POPIA-Aware)",
   "description": null,
   "active": true,

--- a/demos/sme-professional-services/w3-quote-trigger.json
+++ b/demos/sme-professional-services/w3-quote-trigger.json
@@ -1,4 +1,4 @@
-{
+{"id": "2d32384b-dd8d-4e58-84d4-44fb575512c4",
   "name": "W3 - Quote Dispatch",
   "description": null,
   "active": true,

--- a/helm/n8n-application/templates/n8n-deployment.yaml
+++ b/helm/n8n-application/templates/n8n-deployment.yaml
@@ -194,9 +194,6 @@ spec:
               value: {{ include "n8n-application.fullname" . }}-redis
             - name: QUEUE_BULL_REDIS_PORT
               value: {{ .Values.queue.redis.port | default 6379 | quote }}
-            # Ensure graceful shutdown doesn't drop in-flight webhook registrations
-            - name: N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN
-              value: "true"
             {{- end }}
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/projects/gtm-email-sender/README.md
+++ b/projects/gtm-email-sender/README.md
@@ -1,0 +1,133 @@
+# gtm-email-sender — n8n project
+
+Automated send + measure loop for Prudentia Digital n8n GTM outreach.
+
+- **Source pipeline:** `~/Repo/apps/n8n-gtm-research/` writes drafts to Notion DB "GTM Prospects"
+- **n8n role:** sends approved emails at 08:00 SAST daily; tracks bounces, replies, unsubscribes
+- **Email provider:** Resend (SMTP + bounce webhooks)
+- **Sender:** `gtm@prudentiadigital.co.za`
+- **Compliance:** POPIA — every email includes HMAC-signed unsubscribe link
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `gtm-email-sender.json` | Schedule, daily 08:00 SAST | Query Notion `status=approved` rows → send via Resend → mark `sent` |
+| `gtm-bounce-handler.json` | Webhook (Resend posts) | On bounce/complaint → mark Notion `status=bounced` or `unsubscribed` |
+| `gtm-reply-tracker.json` | Schedule, every 30 min | Poll `gtm@prudentiadigital.co.za` Gmail → match `In-Reply-To` → mark `replied` |
+| `gtm-unsubscribe.json` | Webhook (HTML page posts) | Verify HMAC → mark Notion `status=unsubscribed` |
+| `gtm-error-handler.json` | n8n Error Trigger | Set as Error Workflow on the four above → ntfy urgent alert |
+
+## Pre-flight Checklist (run BEFORE first production send)
+
+### Infrastructure prereqs (Day 0)
+
+- [ ] Cloudflare DNS for `prudentiadigital.co.za`:
+      `SPF` TXT: `v=spf1 include:_spf.resend.com ~all`
+      `DKIM` 2× CNAME records from Resend dashboard
+      `DMARC` TXT: `v=DMARC1; p=none; rua=mailto:dmarc@prudentiadigital.co.za; pct=100`
+- [ ] Resend account created; domain `prudentiadigital.co.za` verified (status: "verified")
+- [ ] Resend API key generated (scope: "Sending access")
+- [ ] Resend webhook secret generated; webhook configured to POST to `https://n8n.homelab.local/webhook/gtm-bounce` for events `email.bounced` and `email.complained`
+- [ ] Mailbox `gtm@prudentiadigital.co.za` exists (Cloudflare Email Routing → forward to `ltmaseko7@gmail.com`)
+- [ ] Notion database "GTM Prospects" created with all 22 properties from `~/Repo/apps/n8n-gtm-research/docs/notion-schema.md` (or reproduce from the v2 schema in the plan)
+- [ ] Notion internal integration `n8n-gtm-sender` created; database shared with it
+- [ ] Static `web/unsubscribe.html` deployed to Cloudflare Pages at `prudentiadigital.co.za/unsubscribe` (replace the `WEBHOOK_URL` constant in the page with the actual n8n webhook URL — note `.local` will only work on LAN; for public access route via Cloudflare Tunnel)
+- [ ] POPIA LIA committed at `~/Repo/apps/n8n-gtm-research/docs/popia-lia.md`
+- [ ] Privacy policy live at `prudentiadigital.co.za/privacy`
+
+### n8n environment variables
+
+Set on the `n8n-live` deployment via Vault → ESO (preferred) or directly in Helm `values-live.yaml`:
+
+| Env var | Value | Notes |
+|---|---|---|
+| `NOTION_GTM_DB_ID` | `<32-char Notion DB ID>` | from Notion DB URL |
+| `UNSUBSCRIBE_HMAC_SECRET` | `<64-char hex>` | MUST match the value in `~/Repo/apps/n8n-gtm-research/.env` — same key signs and verifies |
+| `RESEND_WEBHOOK_SECRET` | `whsec_xxxx` | from Resend webhook config |
+| `GTM_DAILY_CAP` | `10` | safety cap |
+| `GTM_FROM_EMAIL` | `gtm@prudentiadigital.co.za` | sender address |
+| `GTM_FROM_NAME` | `Thulani Maseko · Prudentia Digital` | display name |
+| `DEV_OVERRIDE_TO` | `ltmaseko7@gmail.com` | **canary mode — set for first 3 days, unset for production** |
+
+### n8n credentials (manual UI setup, mirrors Google Sheets pattern)
+
+| Credential name | Type | Notes |
+|---|---|---|
+| `notion-gtm` | Notion API | Internal integration token |
+| `resend-api-key` | HTTP Header Auth | Header `Authorization`, value `Bearer re_xxxx` |
+| `gmail-gtm-mailbox` | Gmail OAuth2 | Use localhost OAuth callback workaround — `n8n.homelab.local` won't work for OAuth redirect |
+
+#### Gmail OAuth on `.local` workaround
+1. On the Mac, run a temporary local server: `python3 -m http.server 8080`
+2. Use the n8n Gmail OAuth flow but override the redirect URI to `http://localhost:8080/oauth-callback`
+3. Capture the auth code from the redirect URL
+4. Manually paste the auth code into n8n's credential creation flow
+5. n8n exchanges the code for a refresh token (which doesn't require a public callback — only the initial code exchange does)
+
+### Import workflows
+
+```bash
+# From the homelab Mac/laptop:
+cp ~/Repo/infra/n8n/n8n-self-hosting/projects/gtm-email-sender/workflows/*.json /tmp/
+
+# In n8n UI: Workflows → ⋮ → Import from File → select each JSON
+# After import, re-bind credentials (replace REPLACE_AT_IMPORT placeholders)
+```
+
+### Activate order
+
+1. `gtm-error-handler` — activate first (other workflows reference it)
+2. `gtm-bounce-handler` — activate (passive, waits for Resend webhooks)
+3. `gtm-unsubscribe` — activate (passive, waits for unsubscribe clicks)
+4. `gtm-reply-tracker` — activate (polls Gmail every 30 min)
+5. `gtm-email-sender` — **DO NOT ACTIVATE YET**
+
+## Canary Test (Day 1-3)
+
+With `DEV_OVERRIDE_TO=ltmaseko7@gmail.com` set:
+
+1. Run pipeline `cd ~/Repo/apps/n8n-gtm-research && .venv/bin/python -m src.orchestrator --max-companies 1`
+2. Verify Notion row appears with `status=draft`
+3. Manually approve in Notion: set `status=approved`, fill `email_address` with `ltmaseko7@gmail.com`
+4. Manually trigger `gtm-email-sender` workflow in n8n UI
+5. Verify:
+   - Email arrives in `ltmaseko7@gmail.com` (not the address in Notion — DEV_OVERRIDE wins)
+   - Notion row updates `status=sent`, `sent_at` populated, `resend_message_id` populated
+6. Reply to the email from `ltmaseko7@gmail.com`
+7. Wait ≤30 min → verify Notion `status=replied`, ntfy fires
+8. Click the unsubscribe link → verify Notion `status=unsubscribed`
+9. Send a deliberate bounce: change `email_address` to `bounce@simulator.amazonses.com` (or use Resend's test bounce address) → re-trigger → verify `status=bounced` after Resend webhook fires
+10. Send one canary to `mail-tester.com` test address → score must be ≥9/10
+
+## Production Cutover (Day 4)
+
+After 3 clean canary days:
+
+```bash
+# 1. Unset DEV_OVERRIDE_TO from n8n env (Vault → ESO → restart n8n pod)
+kubectl rollout restart deployment/n8n -n n8n-live
+
+# 2. Verify env var no longer set inside the pod
+kubectl exec -n n8n-live deploy/n8n -- env | grep DEV_OVERRIDE_TO
+# (should be empty)
+
+# 3. Activate gtm-email-sender workflow in n8n UI
+
+# 4. Watch ntfy + Notion at next 08:00 SAST
+```
+
+## Disaster Recovery
+
+- Workflows: re-import from Git (this directory)
+- Credentials: see `vault/secrets.md`
+- Notion data: backed up by Notion (no local export by default; consider weekly export to repo if scale increases)
+- n8n encryption key: at `kv/secret/n8n/live/app` field `N8N_ENCRYPTION_KEY` — losing this means re-entering all credentials manually
+
+## Operational Cadence
+
+- **Daily 08:00 SAST:** auto-send loop fires; check ntfy summary
+- **Weekly:** review `status=replied` rows in Notion; manually advance to discovery call
+- **Weekly:** check `status=bounced` rate; if >5%, investigate sender reputation
+- **Monthly:** export workflow JSONs (`n8n export:workflow`) and `git diff` against this repo to catch UI-side drift
+- **Quarterly:** review `docs/popia-lia.md`; advance DMARC `p=none` → `p=quarantine` after 30 clean days

--- a/projects/gtm-email-sender/manifests/external-secret-gtm-app.yaml
+++ b/projects/gtm-email-sender/manifests/external-secret-gtm-app.yaml
@@ -1,0 +1,27 @@
+# Deploy: move to homelab-infra/apps/n8n-live/manifests/ when formalising ESO for n8n-live.
+# For Wk 1 these values are set directly as env vars in n8n Helm values-live.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gtm-app
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: gtm-email-sender
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: gtm-app
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: UNSUBSCRIBE_HMAC_SECRET
+      remoteRef:
+        key: "secret/n8n/live/gtm-app"
+        property: unsubscribe_hmac_secret
+    - secretKey: NOTION_GTM_DB_ID
+      remoteRef:
+        key: "secret/n8n/live/gtm-app"
+        property: notion_gtm_db_id

--- a/projects/gtm-email-sender/manifests/external-secret-gtm-gmail.yaml
+++ b/projects/gtm-email-sender/manifests/external-secret-gtm-gmail.yaml
@@ -1,0 +1,31 @@
+# Deploy: move to homelab-infra/apps/n8n-live/manifests/ when formalising ESO for n8n-live.
+# For Wk 1 Gmail OAuth credentials are set directly in n8n UI via localhost OAuth workaround.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gtm-gmail
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: gtm-email-sender
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: gtm-gmail
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: GMAIL_CLIENT_ID
+      remoteRef:
+        key: "secret/n8n/live/gtm-gmail"
+        property: client_id
+    - secretKey: GMAIL_CLIENT_SECRET
+      remoteRef:
+        key: "secret/n8n/live/gtm-gmail"
+        property: client_secret
+    - secretKey: GMAIL_REFRESH_TOKEN
+      remoteRef:
+        key: "secret/n8n/live/gtm-gmail"
+        property: refresh_token

--- a/projects/gtm-email-sender/manifests/external-secret-gtm-notion.yaml
+++ b/projects/gtm-email-sender/manifests/external-secret-gtm-notion.yaml
@@ -1,0 +1,23 @@
+# Deploy: move to homelab-infra/apps/n8n-live/manifests/ when formalising ESO for n8n-live.
+# For Wk 1 the Notion token is set as a credential directly in n8n UI.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gtm-notion
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: gtm-email-sender
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: gtm-notion
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: NOTION_API_TOKEN
+      remoteRef:
+        key: "secret/n8n/live/gtm-notion"
+        property: api_token

--- a/projects/gtm-email-sender/manifests/external-secret-gtm-resend.yaml
+++ b/projects/gtm-email-sender/manifests/external-secret-gtm-resend.yaml
@@ -1,0 +1,27 @@
+# Deploy: move to homelab-infra/apps/n8n-live/manifests/ when formalising ESO for n8n-live.
+# For Wk 1 these values are set directly as env vars in n8n Helm values-live.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gtm-resend
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: gtm-email-sender
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: gtm-resend
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESEND_API_KEY
+      remoteRef:
+        key: "secret/n8n/live/gtm-resend"
+        property: api_key
+    - secretKey: RESEND_WEBHOOK_SECRET
+      remoteRef:
+        key: "secret/n8n/live/gtm-resend"
+        property: webhook_secret

--- a/projects/gtm-email-sender/vault/secrets.md
+++ b/projects/gtm-email-sender/vault/secrets.md
@@ -1,0 +1,46 @@
+# gtm-email-sender — Secrets Documentation
+
+This file documents WHICH secrets the workflows depend on and WHERE they live. **Never paste actual secret values here.** Vault stores the truth.
+
+## Vault paths (kv v2 mount)
+
+| Path | Field | Used by | Notes |
+|---|---|---|---|
+| `kv/secret/n8n/live/app` | `N8N_ENCRYPTION_KEY` | All n8n credentials | **DO NOT ROTATE** — losing this means re-entering every credential manually |
+| `kv/secret/n8n/live/gtm-notion` | `api_token` | `notion-gtm` credential | Notion internal integration token, scoped to GTM Prospects DB only |
+| `kv/secret/n8n/live/gtm-resend` | `api_key` | `resend-api-key` credential | Format: `re_xxxxxxxxxxxxxxxx` |
+| `kv/secret/n8n/live/gtm-resend` | `webhook_secret` | `gtm-bounce-handler` env | Format: `whsec_xxxx`; HMAC verification of Resend webhook payloads |
+| `kv/secret/n8n/live/gtm-app` | `unsubscribe_hmac_secret` | All workflows handling slug+token | 64-char hex; **MUST match** `UNSUBSCRIBE_HMAC_SECRET` in `~/Repo/apps/n8n-gtm-research/.env` (same key signs and verifies) |
+| `kv/secret/n8n/live/gtm-app` | `notion_gtm_db_id` | All workflows querying the DB | 32-char Notion DB ID |
+| `kv/secret/n8n/live/gtm-gmail` | `client_id` | `gmail-gtm-mailbox` | Google OAuth2 client ID |
+| `kv/secret/n8n/live/gtm-gmail` | `client_secret` | `gmail-gtm-mailbox` | Google OAuth2 client secret |
+| `kv/secret/n8n/live/gtm-gmail` | `refresh_token` | `gmail-gtm-mailbox` | Long-lived refresh token from localhost OAuth flow |
+
+## ESO ExternalSecret manifests (TODO)
+
+ExternalSecret manifests are **not yet committed** — for Wk 1 we set env vars directly in n8n's Helm values, matching the existing Google Sheets manual pattern (see `demos/sme-professional-services/`).
+
+When ready to formalise, add ExternalSecrets to `~/Repo/infra/homelab-infra/k8s/n8n-live/external-secrets/gtm-*.yaml` mirroring the reelsmith-telegram pattern at `projects/reelsmith-social-publish/`.
+
+## Local (Mac) `.env` file
+
+`~/Repo/apps/n8n-gtm-research/.env` — gitignored, `chmod 600`:
+
+```
+NOTION_API_TOKEN=<same as kv/secret/n8n/live/gtm-notion#api_token>
+NOTION_GTM_DB_ID=<same as kv/secret/n8n/live/gtm-app#notion_gtm_db_id>
+UNSUBSCRIBE_HMAC_SECRET=<same as kv/secret/n8n/live/gtm-app#unsubscribe_hmac_secret>
+```
+
+The HMAC secret MUST be identical on both sides — Mac signs the unsubscribe URL when generating drafts; n8n verifies on click. Mismatch breaks unsubscribe entirely.
+
+## Rotation
+
+| Secret | Rotation cadence | Procedure |
+|---|---|---|
+| `N8N_ENCRYPTION_KEY` | NEVER (without coordinated re-credential entry) | n/a |
+| Notion `api_token` | On suspected leak | Revoke at notion.so/my-integrations → generate new → update Vault → ESO refresh → update Mac `.env` |
+| Resend `api_key` | Quarterly | Generate new in Resend dashboard → update Vault → ESO refresh; old key auto-revoked when replaced |
+| Resend `webhook_secret` | On suspected leak | Regenerate in Resend webhook config → update Vault → restart n8n pod |
+| `unsubscribe_hmac_secret` | On suspected leak | `openssl rand -hex 32` → update BOTH Vault AND Mac `.env` AT THE SAME TIME → re-run pipeline (existing in-flight unsubscribe links will be invalidated) |
+| Gmail `refresh_token` | Lasts indefinitely | Re-do localhost OAuth flow if revoked |

--- a/projects/gtm-email-sender/workflows/gtm-bounce-handler.json
+++ b/projects/gtm-email-sender/workflows/gtm-bounce-handler.json
@@ -1,0 +1,134 @@
+{
+  "name": "gtm-bounce-handler",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "saveExecutionProgress": true,
+    "saveManualExecutions": true,
+    "errorWorkflow": "gtm-error-handler"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "gtm-bounce",
+        "responseMode": "lastNode",
+        "options": {
+          "responseData": "{\"ok\":true}",
+          "responseCode": 200
+        }
+      },
+      "id": "b1b1b1b1-1111-4111-8111-111111111111",
+      "name": "Resend Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "gtm-bounce"
+    },
+    {
+      "parameters": {
+        "language": "javaScript",
+        "jsCode": "// Verify Resend webhook signature (svix-style HMAC-SHA256)\nconst crypto = require('crypto');\nconst secret = $env.RESEND_WEBHOOK_SECRET;\nif (!secret) throw new Error('RESEND_WEBHOOK_SECRET not set');\n\nconst headers = $input.first().json.headers || {};\nconst sigHeader = headers['svix-signature'] || headers['Svix-Signature'] || '';\nconst msgId = headers['svix-id'] || headers['Svix-Id'] || '';\nconst timestamp = headers['svix-timestamp'] || headers['Svix-Timestamp'] || '';\nconst body = $input.first().json.body || $input.first().json;\n\nconst signedPayload = `${msgId}.${timestamp}.${typeof body === 'string' ? body : JSON.stringify(body)}`;\nconst expected = crypto.createHmac('sha256', Buffer.from(secret.replace(/^whsec_/, ''), 'base64'))\n  .update(signedPayload)\n  .digest('base64');\n\nconst signatures = sigHeader.split(' ').map(s => s.split(',')[1]).filter(Boolean);\nconst valid = signatures.includes(expected);\n\nif (!valid) {\n  // In production, throw to reject 401. For initial setup, log+continue while validating.\n  console.warn('Invalid Resend webhook signature — got=', sigHeader, 'expected=', expected);\n}\n\nconst event = body.type || body.event || '';\nconst data = body.data || {};\nreturn [{ json: { event, message_id: data.email_id || data.id, reason: (data.bounce && data.bounce.reason) || (data.complaint && data.complaint.type) || '', raw: body } }];"
+      },
+      "id": "b2b2b2b2-2222-4222-8222-222222222222",
+      "name": "Verify + Parse",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "getAll",
+        "databaseId": "={{ $env.NOTION_GTM_DB_ID }}",
+        "returnAll": false,
+        "limit": 1,
+        "filters": {
+          "conditions": [
+            {
+              "key": "resend_message_id|rich_text",
+              "condition": "equals",
+              "richTextValue": "={{ $json.message_id }}"
+            }
+          ]
+        }
+      },
+      "id": "b3b3b3b3-3333-4333-8333-333333333333",
+      "name": "Find Notion Page",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "update",
+        "pageId": "={{ $json.id }}",
+        "propertiesUi": {
+          "propertyValues": [
+            {
+              "key": "status|select",
+              "selectValue": "={{ $('Verify + Parse').item.json.event === 'email.complained' ? 'unsubscribed' : 'bounced' }}"
+            },
+            {
+              "key": "bounced_at|date",
+              "date": "={{ $now.toISO() }}"
+            },
+            {
+              "key": "notes|rich_text",
+              "richText": true,
+              "textContent": "={{ 'Bounce/complaint: ' + $('Verify + Parse').item.json.reason }}"
+            }
+          ]
+        }
+      },
+      "id": "b4b4b4b4-4444-4444-8444-444444444444",
+      "name": "Notion Update Bounced",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [900, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://ntfy.sh/prudentia-alerts",
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "=Bounce/complaint: {{ $('Verify + Parse').item.json.reason }} (msg {{ $('Verify + Parse').item.json.message_id }})",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Title", "value": "n8n-gtm bounce/complaint"},
+            {"name": "Priority", "value": "high"},
+            {"name": "Tags", "value": "warning"}
+          ]
+        }
+      },
+      "id": "b5b5b5b5-5555-4555-8555-555555555555",
+      "name": "ntfy Bounce Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    }
+  ],
+  "connections": {
+    "Resend Webhook": {"main": [[{"node": "Verify + Parse", "type": "main", "index": 0}]]},
+    "Verify + Parse": {"main": [[{"node": "Find Notion Page", "type": "main", "index": 0}]]},
+    "Find Notion Page": {"main": [[{"node": "Notion Update Bounced", "type": "main", "index": 0}]]},
+    "Notion Update Bounced": {"main": [[{"node": "ntfy Bounce Alert", "type": "main", "index": 0}]]}
+  },
+  "tags": [{"name": "gtm"}, {"name": "prudentia-digital"}],
+  "pinData": {}
+}

--- a/projects/gtm-email-sender/workflows/gtm-email-sender.json
+++ b/projects/gtm-email-sender/workflows/gtm-email-sender.json
@@ -1,0 +1,288 @@
+{
+  "name": "gtm-email-sender",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "saveExecutionProgress": true,
+    "saveManualExecutions": true,
+    "saveDataErrorExecution": "all",
+    "saveDataSuccessExecution": "all",
+    "errorWorkflow": "gtm-error-handler",
+    "timezone": "Africa/Johannesburg"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 8 * * *"
+            }
+          ]
+        }
+      },
+      "id": "1a1a1a1a-1111-4111-8111-111111111111",
+      "name": "Schedule 08:00 SAST",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "getAll",
+        "databaseId": "={{ $env.NOTION_GTM_DB_ID }}",
+        "returnAll": false,
+        "limit": "={{ parseInt($env.GTM_DAILY_CAP || '10') }}",
+        "filters": {
+          "conditions": [
+            {
+              "key": "status|select",
+              "condition": "equals",
+              "selectValue": "approved"
+            },
+            {
+              "key": "sent_at|date",
+              "condition": "is_empty"
+            },
+            {
+              "key": "email_address|email",
+              "condition": "is_not_empty"
+            }
+          ]
+        }
+      },
+      "id": "2b2b2b2b-2222-4222-8222-222222222222",
+      "name": "Notion Query Approved",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [460, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-empty",
+              "leftValue": "={{ $items().length }}",
+              "rightValue": 0,
+              "operator": {
+                "type": "number",
+                "operation": "gt"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "3c3c3c3c-3333-4333-8333-333333333333",
+      "name": "IF has rows",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "language": "javaScript",
+        "jsCode": "// POPIA pre-send guard — verify unsubscribe URL is present and HMAC matches.\nconst crypto = require('crypto');\nconst secret = $env.UNSUBSCRIBE_HMAC_SECRET;\nif (!secret) throw new Error('UNSUBSCRIBE_HMAC_SECRET not set in n8n env');\n\nfunction hmac(slug) {\n  return crypto.createHmac('sha256', secret).update(slug).digest('hex');\n}\n\nconst out = [];\nfor (const item of $input.all()) {\n  const props = item.json.properties || item.json;\n  const slug = (props.slug?.rich_text?.[0]?.plain_text) || props.slug || '';\n  const body = (props.email_body?.rich_text?.map(t => t.plain_text).join('') || props.email_body || '');\n  const expectedToken = hmac(slug);\n  const hasUrl = body.includes('unsubscribe') && body.includes(`token=${expectedToken}`);\n  if (!hasUrl) {\n    out.push({ json: { ...item.json, _compliance_skip: true, _compliance_reason: 'unsubscribe URL missing or HMAC mismatch' } });\n  } else {\n    out.push({ json: { ...item.json, _compliance_skip: false } });\n  }\n}\nreturn out;"
+      },
+      "id": "4d4d4d4d-4444-4444-8444-444444444444",
+      "name": "POPIA Pre-Send Guard",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      },
+      "id": "5e5e5e5e-5555-4555-8555-555555555555",
+      "name": "Loop Over Items",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "amount": "={{ 30 + Math.floor(Math.random() * 60) }}",
+        "unit": "seconds"
+      },
+      "id": "6f6f6f6f-6666-4666-8666-666666666666",
+      "name": "Wait Jitter 30-90s",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [1340, 200],
+      "webhookId": "gtm-email-sender-wait"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.resend.com/emails",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"from\": \"{{ $env.GTM_FROM_NAME || 'Thulani Maseko · Prudentia Digital' }} <{{ $env.GTM_FROM_EMAIL || 'gtm@prudentiadigital.co.za' }}>\",\n  \"to\": [\"{{ $env.DEV_OVERRIDE_TO || $json.properties.email_address.email }}\"],\n  \"reply_to\": \"{{ $env.GTM_FROM_EMAIL || 'gtm@prudentiadigital.co.za' }}\",\n  \"subject\": \"{{ $json.properties.email_subject.rich_text[0].plain_text }}\",\n  \"text\": \"{{ $json.properties.email_body.rich_text.map(t => t.plain_text).join('').replace(/\"/g, '\\\\\"').replace(/\\n/g, '\\\\n') }}\",\n  \"tags\": [\n    {\"name\": \"campaign\", \"value\": \"gtm-week1\"},\n    {\"name\": \"domain\", \"value\": \"{{ $json.properties.domain.rich_text[0].plain_text }}\"}\n  ]\n}",
+        "options": {
+          "retry": {
+            "tryCount": 3,
+            "waitBetweenTries": 5000
+          }
+        }
+      },
+      "id": "7a7a7a7a-7777-4777-8777-777777777777",
+      "name": "Resend Send Email",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "resend-api-key"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "update",
+        "pageId": "={{ $('Loop Over Items').item.json.id }}",
+        "propertiesUi": {
+          "propertyValues": [
+            {
+              "key": "status|select",
+              "selectValue": "={{ $json.error ? 'failed' : 'sent' }}"
+            },
+            {
+              "key": "sent_at|date",
+              "date": "={{ $now.toISO() }}"
+            },
+            {
+              "key": "resend_message_id|rich_text",
+              "richText": true,
+              "textContent": "={{ $json.id || 'failed' }}"
+            },
+            {
+              "key": "notes|rich_text",
+              "richText": true,
+              "textContent": "={{ $json.error ? ('Send error: ' + JSON.stringify($json.error)) : '' }}"
+            }
+          ]
+        }
+      },
+      "id": "8b8b8b8b-8888-4888-8888-888888888888",
+      "name": "Notion Update Sent",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [1780, 200],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://ntfy.sh/prudentia-alerts",
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "=n8n-gtm: send loop complete. Check Notion for status updates.",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Title", "value": "n8n-gtm send loop done"},
+            {"name": "Priority", "value": "default"}
+          ]
+        }
+      },
+      "id": "9c9c9c9c-9999-4999-8999-999999999999",
+      "name": "ntfy Done",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://ntfy.sh/prudentia-alerts",
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "=n8n-gtm: nothing to send (no approved rows in Notion).",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Title", "value": "n8n-gtm idle"},
+            {"name": "Priority", "value": "low"}
+          ]
+        }
+      },
+      "id": "0d0d0d0d-0000-4000-8000-000000000000",
+      "name": "ntfy Idle",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 400]
+    }
+  ],
+  "connections": {
+    "Schedule 08:00 SAST": {
+      "main": [[{"node": "Notion Query Approved", "type": "main", "index": 0}]]
+    },
+    "Notion Query Approved": {
+      "main": [[{"node": "IF has rows", "type": "main", "index": 0}]]
+    },
+    "IF has rows": {
+      "main": [
+        [{"node": "POPIA Pre-Send Guard", "type": "main", "index": 0}],
+        [{"node": "ntfy Idle", "type": "main", "index": 0}]
+      ]
+    },
+    "POPIA Pre-Send Guard": {
+      "main": [[{"node": "Loop Over Items", "type": "main", "index": 0}]]
+    },
+    "Loop Over Items": {
+      "main": [
+        [{"node": "ntfy Done", "type": "main", "index": 0}],
+        [{"node": "Wait Jitter 30-90s", "type": "main", "index": 0}]
+      ]
+    },
+    "Wait Jitter 30-90s": {
+      "main": [[{"node": "Resend Send Email", "type": "main", "index": 0}]]
+    },
+    "Resend Send Email": {
+      "main": [[{"node": "Notion Update Sent", "type": "main", "index": 0}]]
+    },
+    "Notion Update Sent": {
+      "main": [[{"node": "Loop Over Items", "type": "main", "index": 0}]]
+    }
+  },
+  "tags": [
+    {"name": "gtm"},
+    {"name": "prudentia-digital"}
+  ],
+  "pinData": {}
+}

--- a/projects/gtm-email-sender/workflows/gtm-error-handler.json
+++ b/projects/gtm-email-sender/workflows/gtm-error-handler.json
@@ -1,0 +1,47 @@
+{
+  "name": "gtm-error-handler",
+  "active": true,
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "saveDataErrorExecution": "all",
+    "saveDataSuccessExecution": "none"
+  },
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "e1e1e1e1-1111-4111-8111-111111111111",
+      "name": "Error Trigger",
+      "type": "n8n-nodes-base.errorTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://ntfy.sh/prudentia-alerts",
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "=n8n-gtm WORKFLOW FAILURE: {{ $json.workflow.name }} | last node: {{ $json.execution.lastNodeExecuted }} | error: {{ $json.execution.error.message }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Title", "value": "n8n-gtm workflow error"},
+            {"name": "Priority", "value": "urgent"},
+            {"name": "Tags", "value": "rotating_light"}
+          ]
+        }
+      },
+      "id": "e2e2e2e2-2222-4222-8222-222222222222",
+      "name": "ntfy High Priority",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 300]
+    }
+  ],
+  "connections": {
+    "Error Trigger": {"main": [[{"node": "ntfy High Priority", "type": "main", "index": 0}]]}
+  },
+  "tags": [{"name": "gtm"}, {"name": "prudentia-digital"}],
+  "pinData": {}
+}

--- a/projects/gtm-email-sender/workflows/gtm-reply-tracker.json
+++ b/projects/gtm-email-sender/workflows/gtm-reply-tracker.json
@@ -1,0 +1,148 @@
+{
+  "name": "gtm-reply-tracker",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "saveExecutionProgress": true,
+    "saveManualExecutions": true,
+    "errorWorkflow": "gtm-error-handler"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 30
+            }
+          ]
+        }
+      },
+      "id": "r1r1r1r1-1111-4111-8111-111111111111",
+      "name": "Every 30 minutes",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "getAll",
+        "returnAll": false,
+        "limit": 25,
+        "filters": {
+          "q": "in:inbox is:unread newer_than:1d",
+          "readStatus": "unread"
+        }
+      },
+      "id": "r2r2r2r2-2222-4222-8222-222222222222",
+      "name": "Gmail Get Unread",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2.1,
+      "position": [460, 300],
+      "credentials": {
+        "gmailOAuth2": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "gmail-gtm-mailbox"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "language": "javaScript",
+        "jsCode": "// Extract In-Reply-To header — that matches a Resend message-id we've stored in Notion.\nconst out = [];\nfor (const item of $input.all()) {\n  const headers = (item.json.payload && item.json.payload.headers) || item.json.headers || [];\n  let inReplyTo = '';\n  let subject = '';\n  let from = '';\n  for (const h of headers) {\n    if (!h.name) continue;\n    const lower = h.name.toLowerCase();\n    if (lower === 'in-reply-to') inReplyTo = (h.value || '').replace(/[<>]/g, '');\n    if (lower === 'subject') subject = h.value || '';\n    if (lower === 'from') from = h.value || '';\n  }\n  if (!inReplyTo) continue;\n  const snippet = (item.json.snippet || '').slice(0, 500);\n  out.push({ json: { inReplyTo, subject, from, snippet, gmailId: item.json.id } });\n}\nreturn out;"
+      },
+      "id": "r3r3r3r3-3333-4333-8333-333333333333",
+      "name": "Extract In-Reply-To",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "getAll",
+        "databaseId": "={{ $env.NOTION_GTM_DB_ID }}",
+        "returnAll": false,
+        "limit": 1,
+        "filters": {
+          "conditions": [
+            {
+              "key": "resend_message_id|rich_text",
+              "condition": "equals",
+              "richTextValue": "={{ $json.inReplyTo }}"
+            }
+          ]
+        }
+      },
+      "id": "r4r4r4r4-4444-4444-8444-444444444444",
+      "name": "Find Notion Page",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [900, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "update",
+        "pageId": "={{ $json.id }}",
+        "propertiesUi": {
+          "propertyValues": [
+            {"key": "status|select", "selectValue": "replied"},
+            {"key": "replied_at|date", "date": "={{ $now.toISO() }}"},
+            {"key": "notes|rich_text", "richText": true, "textContent": "={{ 'Reply: ' + $('Extract In-Reply-To').item.json.snippet }}"}
+          ]
+        }
+      },
+      "id": "r5r5r5r5-5555-4555-8555-555555555555",
+      "name": "Notion Update Replied",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [1120, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://ntfy.sh/prudentia-alerts",
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "=Reply received: {{ $('Extract In-Reply-To').item.json.subject }} (from {{ $('Extract In-Reply-To').item.json.from }})",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Title", "value": "GTM REPLY"},
+            {"name": "Priority", "value": "high"},
+            {"name": "Tags", "value": "tada,star"}
+          ]
+        }
+      },
+      "id": "r6r6r6r6-6666-4666-8666-666666666666",
+      "name": "ntfy Reply Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Every 30 minutes": {"main": [[{"node": "Gmail Get Unread", "type": "main", "index": 0}]]},
+    "Gmail Get Unread": {"main": [[{"node": "Extract In-Reply-To", "type": "main", "index": 0}]]},
+    "Extract In-Reply-To": {"main": [[{"node": "Find Notion Page", "type": "main", "index": 0}]]},
+    "Find Notion Page": {"main": [[{"node": "Notion Update Replied", "type": "main", "index": 0}]]},
+    "Notion Update Replied": {"main": [[{"node": "ntfy Reply Alert", "type": "main", "index": 0}]]}
+  },
+  "tags": [{"name": "gtm"}, {"name": "prudentia-digital"}],
+  "pinData": {}
+}

--- a/projects/gtm-email-sender/workflows/gtm-unsubscribe.json
+++ b/projects/gtm-email-sender/workflows/gtm-unsubscribe.json
@@ -1,0 +1,102 @@
+{
+  "name": "gtm-unsubscribe",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "saveExecutionProgress": true,
+    "saveManualExecutions": true,
+    "errorWorkflow": "gtm-error-handler"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "gtm-unsubscribe",
+        "responseMode": "lastNode",
+        "options": {
+          "responseData": "<!doctype html><html><head><title>Unsubscribed</title><style>body{font-family:system-ui;max-width:480px;margin:6rem auto;padding:2rem;text-align:center;color:#1a1a1a}</style></head><body><h1>You're unsubscribed</h1><p>You won't hear from us again.</p></body></html>",
+          "responseCode": 200,
+          "responseContentType": "text/html"
+        }
+      },
+      "id": "u1u1u1u1-1111-4111-8111-111111111111",
+      "name": "Unsubscribe Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "gtm-unsubscribe"
+    },
+    {
+      "parameters": {
+        "language": "javaScript",
+        "jsCode": "const crypto = require('crypto');\nconst secret = $env.UNSUBSCRIBE_HMAC_SECRET;\nif (!secret) throw new Error('UNSUBSCRIBE_HMAC_SECRET not set');\n\nconst query = $input.first().json.query || {};\nconst slug = query.slug || '';\nconst token = query.token || '';\nif (!slug || !token) throw new Error('missing slug or token');\n\nconst expected = crypto.createHmac('sha256', secret).update(slug).digest('hex');\nif (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(token))) {\n  throw new Error('invalid token');\n}\nreturn [{ json: { slug } }];"
+      },
+      "id": "u2u2u2u2-2222-4222-8222-222222222222",
+      "name": "Verify HMAC",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "getAll",
+        "databaseId": "={{ $env.NOTION_GTM_DB_ID }}",
+        "returnAll": false,
+        "limit": 1,
+        "filters": {
+          "conditions": [
+            {
+              "key": "slug|rich_text",
+              "condition": "equals",
+              "richTextValue": "={{ $json.slug }}"
+            }
+          ]
+        }
+      },
+      "id": "u3u3u3u3-3333-4333-8333-333333333333",
+      "name": "Find Notion Page",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "databasePage",
+        "operation": "update",
+        "pageId": "={{ $json.id }}",
+        "propertiesUi": {
+          "propertyValues": [
+            {"key": "status|select", "selectValue": "unsubscribed"},
+            {"key": "unsubscribed_at|date", "date": "={{ $now.toISO() }}"},
+            {"key": "notes|rich_text", "richText": true, "textContent": "Unsubscribed via link"}
+          ]
+        }
+      },
+      "id": "u4u4u4u4-4444-4444-8444-444444444444",
+      "name": "Notion Mark Unsubscribed",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [900, 300],
+      "credentials": {
+        "notionApi": {
+          "id": "REPLACE_AT_IMPORT",
+          "name": "notion-gtm"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Unsubscribe Webhook": {"main": [[{"node": "Verify HMAC", "type": "main", "index": 0}]]},
+    "Verify HMAC": {"main": [[{"node": "Find Notion Page", "type": "main", "index": 0}]]},
+    "Find Notion Page": {"main": [[{"node": "Notion Mark Unsubscribed", "type": "main", "index": 0}]]}
+  },
+  "tags": [{"name": "gtm"}, {"name": "prudentia-digital"}],
+  "pinData": {}
+}

--- a/projects/reelsmith-social-publish/manifests/tiktok-sidecar-cookies-secret.yaml.example
+++ b/projects/reelsmith-social-publish/manifests/tiktok-sidecar-cookies-secret.yaml.example
@@ -1,0 +1,33 @@
+# NOT applied via ArgoCD. Template only.
+#
+# The real `tiktok-sidecar-cookies` Secret is created out-of-band by the
+# operator after running the interactive login on Mac:
+#
+#   scp CookiesDir/tiktok_session-reelsmith.cookie homelab:/tmp/
+#   ssh homelab "microk8s kubectl -n n8n-live create secret generic \
+#     tiktok-sidecar-cookies \
+#     --from-file=tiktok_session-reelsmith.cookie=/tmp/tiktok_session-reelsmith.cookie \
+#     --dry-run=client -o yaml | microk8s kubectl apply -f -"
+#   ssh homelab "rm /tmp/tiktok_session-reelsmith.cookie"
+#   ssh homelab "microk8s kubectl -n n8n-live rollout restart deploy/tiktok-sidecar"
+#
+# Cookies expire every 2-4 weeks. Refresh monthly OR when sidecar logs show
+# 401/403 errors. Refresh procedure is the same as initial bootstrap.
+#
+# CRITICAL: never `kubectl delete pod` for cookie refresh. ArgoCD selfHeal
+# will recreate the pod before initContainer re-runs. Always `rollout restart`.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tiktok-sidecar-cookies
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/name: tiktok-sidecar
+    app.kubernetes.io/part-of: reelsmith-social-publish
+type: Opaque
+data:
+  # Real cookies are base64-encoded by kubectl when using --from-file.
+  # Filename pattern: tiktok_session-<account>.cookie (NOT <account>.cookie).
+  # File contents come from the makiisthenes uploader's login flow.
+  tiktok_session-reelsmith.cookie: <base64-encoded-cookie-blob-from-Mac>

--- a/projects/reelsmith-social-publish/manifests/tiktok-sidecar-deployment.yaml
+++ b/projects/reelsmith-social-publish/manifests/tiktok-sidecar-deployment.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tiktok-sidecar
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/name: tiktok-sidecar
+    app.kubernetes.io/part-of: reelsmith-social-publish
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tiktok-sidecar
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tiktok-sidecar
+        app.kubernetes.io/part-of: reelsmith-social-publish
+    spec:
+      # initContainer seeds CookiesDir from the out-of-band Secret on first
+      # pod start (and on every rollout restart). Cookies must be refreshed
+      # via `kubectl rollout restart deploy/tiktok-sidecar` after a Secret
+      # update — NEVER `kubectl delete pod` (ArgoCD selfHeal recreates it
+      # before the initContainer re-runs).
+      initContainers:
+        - name: seed-cookies
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              if [ -z "$(ls -A /app/CookiesDir 2>/dev/null)" ]; then
+                echo "seed-cookies: copying cookies from /secrets to /app/CookiesDir"
+                cp -v /secrets/*.cookie /app/CookiesDir/ 2>/dev/null || \
+                  echo "seed-cookies: no .cookie files in /secrets (Secret may be empty until operator bootstraps)"
+              else
+                echo "seed-cookies: /app/CookiesDir already populated, skipping"
+                ls -la /app/CookiesDir
+              fi
+          volumeMounts:
+            - name: cookies-pvc
+              mountPath: /app/CookiesDir
+            - name: cookies-secret
+              mountPath: /secrets
+              readOnly: true
+      containers:
+        - name: tiktok-sidecar
+          image: localhost:32000/reelsmith/tiktok-sidecar:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MOCK_UPLOAD
+              value: "false"
+            - name: COOKIES_DIR
+              value: /app/CookiesDir
+            - name: UPLOADER_PATH
+              value: /opt/uploader/cli.py
+          volumeMounts:
+            - name: cookies-pvc
+              mountPath: /app/CookiesDir
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: cookies-pvc
+          persistentVolumeClaim:
+            claimName: tiktok-sidecar-cookies-pvc
+        - name: cookies-secret
+          secret:
+            secretName: tiktok-sidecar-cookies
+            optional: true
+            defaultMode: 0400

--- a/projects/reelsmith-social-publish/manifests/tiktok-sidecar-pvc.yaml
+++ b/projects/reelsmith-social-publish/manifests/tiktok-sidecar-pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tiktok-sidecar-cookies-pvc
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/name: tiktok-sidecar
+    app.kubernetes.io/part-of: reelsmith-social-publish
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: microk8s-hostpath-immediate
+  resources:
+    requests:
+      storage: 1Gi

--- a/projects/reelsmith-social-publish/manifests/tiktok-sidecar-service.yaml
+++ b/projects/reelsmith-social-publish/manifests/tiktok-sidecar-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tiktok-sidecar
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/name: tiktok-sidecar
+    app.kubernetes.io/part-of: reelsmith-social-publish
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tiktok-sidecar
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP

--- a/projects/reelsmith-social-publish/workflow/reelsmith-social-publish.json
+++ b/projects/reelsmith-social-publish/workflow/reelsmith-social-publish.json
@@ -13,7 +13,9 @@
     {
       "parameters": {
         "path": "/data/reelsmith-inbox",
-        "events": ["add"],
+        "events": [
+          "add"
+        ],
         "options": {
           "depth": -1,
           "followSymlinks": false
@@ -24,7 +26,10 @@
       "name": "Local File Trigger",
       "type": "n8n-nodes-base.localFileTrigger",
       "typeVersion": 1,
-      "position": [250, 300]
+      "position": [
+        250,
+        300
+      ]
     },
     {
       "parameters": {
@@ -35,7 +40,10 @@
       "name": "Index Clips",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [450, 300]
+      "position": [
+        450,
+        300
+      ]
     },
     {
       "parameters": {
@@ -46,7 +54,10 @@
       "name": "Assign Peak Window",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [650, 300]
+      "position": [
+        650,
+        300
+      ]
     },
     {
       "parameters": {
@@ -57,7 +68,10 @@
       "name": "Wait",
       "type": "n8n-nodes-base.wait",
       "typeVersion": 1,
-      "position": [850, 300],
+      "position": [
+        850,
+        300
+      ],
       "webhookId": "reelsmith-social-publish-wait"
     },
     {
@@ -69,63 +83,10 @@
       "name": "Read Clip File",
       "type": "n8n-nodes-base.readBinaryFile",
       "typeVersion": 1,
-      "position": [1050, 300]
-    },
-    {
-      "parameters": {
-        "method": "POST",
-        "url": "https://open.tiktokapis.com/v2/post/publish/inbox/video/init/",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "oAuth2Api",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            { "name": "Content-Type", "value": "application/json; charset=UTF-8" }
-          ]
-        },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ post_info: { title: ($json.title || '').substring(0, 150), privacy_level: 'SELF_ONLY' }, source_info: { source: 'FILE_UPLOAD', video_size: $binary.clipBinary.fileSize, chunk_size: 10485760, total_chunk_count: Math.ceil($binary.clipBinary.fileSize / 10485760) } }) }}",
-        "options": { "response": { "response": { "neverError": true } } }
-      },
-      "id": "66666666-6666-4666-8666-666666666666",
-      "name": "TikTok Init",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4,
-      "position": [1250, 180],
-      "credentials": { "oAuth2Api": { "id": "reelsmith-tiktok", "name": "reelsmith-tiktok" } },
-      "continueOnFail": true
-    },
-    {
-      "parameters": {
-        "language": "javaScript",
-        "jsCode": "const fs = require('fs');\nconst filePath = $('Read Clip File').item.json.export_path;\nconst out = { ...$('Read Clip File').item.json };\n\ntry {\n  const init = $json;\n  if (!init || !init.data || !init.data.upload_url || !init.data.publish_id) {\n    throw new Error('TikTok init failed: ' + JSON.stringify(init).substring(0, 300));\n  }\n  const uploadUrl = init.data.upload_url;\n  out.tiktok_publish_id = init.data.publish_id;\n\n  const CHUNK = 10 * 1024 * 1024;\n  const stat = fs.statSync(filePath);\n  const total = stat.size;\n  const fd = fs.openSync(filePath, 'r');\n  let offset = 0;\n\n  while (offset < total) {\n    const len = Math.min(CHUNK, total - offset);\n    const buf = Buffer.alloc(len);\n    fs.readSync(fd, buf, 0, len, offset);\n    const resp = await this.helpers.httpRequest({\n      method: 'PUT',\n      url: uploadUrl,\n      body: buf,\n      headers: {\n        'Content-Type': 'video/mp4',\n        'Content-Length': String(len),\n        'Content-Range': `bytes ${offset}-${offset + len - 1}/${total}`\n      },\n      returnFullResponse: true,\n      encoding: null\n    });\n    if (resp.statusCode >= 400) {\n      throw new Error(`Chunk ${offset} upload failed: HTTP ${resp.statusCode}`);\n    }\n    offset += len;\n  }\n  fs.closeSync(fd);\n  out.tiktok_upload_status = 'uploaded';\n} catch (err) {\n  out.tiktok_error = String(err.message || err);\n  out.tiktok_upload_status = 'failed';\n}\n\nreturn [{ json: out, binary: $binary }];"
-      },
-      "id": "77777777-7777-4777-8777-777777777777",
-      "name": "TikTok Upload",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [1450, 180]
-    },
-    {
-      "parameters": {
-        "method": "GET",
-        "url": "https://open.tiktokapis.com/v2/post/publish/status/fetch/",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "oAuth2Api",
-        "sendQuery": true,
-        "queryParameters": {
-          "parameters": [{ "name": "publish_id", "value": "={{ $json.tiktok_publish_id }}" }]
-        },
-        "options": { "response": { "response": { "neverError": true } } }
-      },
-      "id": "88888888-8888-4888-8888-888888888888",
-      "name": "TikTok Poll Status",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4,
-      "position": [1650, 180],
-      "credentials": { "oAuth2Api": { "id": "reelsmith-tiktok", "name": "reelsmith-tiktok" } },
-      "continueOnFail": true
+      "position": [
+        1050,
+        300
+      ]
     },
     {
       "parameters": {
@@ -136,22 +97,46 @@
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
-            { "name": "Content-Type", "value": "application/json; charset=UTF-8" },
-            { "name": "X-Upload-Content-Type", "value": "video/mp4" },
-            { "name": "X-Upload-Content-Length", "value": "={{ $binary.clipBinary.fileSize }}" }
+            {
+              "name": "Content-Type",
+              "value": "application/json; charset=UTF-8"
+            },
+            {
+              "name": "X-Upload-Content-Type",
+              "value": "video/mp4"
+            },
+            {
+              "name": "X-Upload-Content-Length",
+              "value": "={{ $binary.clipBinary.fileSize }}"
+            }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ snippet: { title: ($json.title || '').substring(0, 100), description: ($json.description || '') + '\\n\\n#Shorts', tags: (() => { try { return JSON.parse($json.hashtags || '[]').map(h => String(h).replace('#', '')); } catch(e) { return []; } })() }, status: { privacyStatus: 'private' } }) }}",
-        "options": { "response": { "response": { "fullResponse": true, "neverError": true } } }
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          }
+        }
       },
       "id": "99999999-9999-4999-8999-999999999999",
       "name": "YouTube Init",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4,
-      "position": [1250, 420],
-      "credentials": { "oAuth2Api": { "id": "reelsmith-youtube", "name": "reelsmith-youtube" } },
+      "position": [
+        1250,
+        420
+      ],
+      "credentials": {
+        "oAuth2Api": {
+          "id": "reelsmith-youtube",
+          "name": "reelsmith-youtube"
+        }
+      },
       "continueOnFail": true
     },
     {
@@ -163,7 +148,10 @@
       "name": "YouTube Capture Session",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1450, 420]
+      "position": [
+        1450,
+        420
+      ]
     },
     {
       "parameters": {
@@ -172,19 +160,31 @@
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
-            { "name": "Content-Type", "value": "video/mp4" }
+            {
+              "name": "Content-Type",
+              "value": "video/mp4"
+            }
           ]
         },
         "sendBody": true,
         "contentType": "binaryData",
         "inputDataFieldName": "clipBinary",
-        "options": { "response": { "response": { "neverError": true } } }
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true
+            }
+          }
+        }
       },
       "id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       "name": "YouTube Upload",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4,
-      "position": [1650, 420],
+      "position": [
+        1650,
+        420
+      ],
       "continueOnFail": true
     },
     {
@@ -197,41 +197,60 @@
       "name": "Merge Results",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 2,
-      "position": [1850, 300]
+      "position": [
+        1850,
+        300
+      ]
     },
     {
       "parameters": {
         "language": "javaScript",
-        "jsCode": "const fs = require('fs');\nconst path = require('path');\n\nconst HEADER = 'timestamp,filename,title,tiktok_publish_id,tiktok_status,youtube_video_id,youtube_status,error\\n';\n\nfunction csvEscape(v) {\n  const s = String(v == null ? '' : v);\n  return (s.includes(',') || s.includes('\"') || s.includes('\\n'))\n    ? '\"' + s.replace(/\"/g, '\"\"') + '\"'\n    : s;\n}\n\nconst out = [];\nfor (const item of $input.all()) {\n  const j = item.json;\n  const logPath = path.join(j.jobDir, 'results.log.csv');\n\n  const tiktokStatus = j.tiktok_upload_status || (j.data && j.data.status) || '';\n  const youtubeId    = (j.id) || (j.body && j.body.id) || '';\n  const youtubeStatus = j.youtube_error ? 'failed' : (youtubeId ? 'uploaded' : 'unknown');\n  const errors = [j.tiktok_error, j.youtube_error].filter(Boolean).join(' | ');\n\n  const row = [\n    new Date().toISOString(),\n    j.filename || path.basename(j.export_path || ''),\n    j.title || '',\n    j.tiktok_publish_id || '',\n    tiktokStatus,\n    youtubeId,\n    youtubeStatus,\n    errors\n  ].map(csvEscape).join(',') + '\\n';\n\n  if (!fs.existsSync(logPath)) fs.writeFileSync(logPath, HEADER);\n  fs.appendFileSync(logPath, row);\n\n  if (errors) {\n    try {\n      const token = process.env.TELEGRAM_BOT_TOKEN;\n      const chatId = process.env.TELEGRAM_CHAT_ID;\n      if (token && chatId) {\n        await this.helpers.httpRequest({\n          method: 'POST',\n          url: `https://api.telegram.org/bot${token}/sendMessage`,\n          json: true,\n          body: {\n            chat_id: chatId,\n            text: `Reelsmith publish FAILED\\nfile: ${j.filename || j.export_path}\\nerror: ${errors}`\n          }\n        });\n      }\n    } catch (_) { /* swallow alert errors */ }\n  }\n\n  out.push({ json: { ...j, logged: true } });\n}\nreturn out;"
+        "jsCode": "const fs = require('fs');\nconst path = require('path');\n\nconst HEADER = 'timestamp,filename,title,tiktok_post_id,tiktok_post_url,youtube_video_id,youtube_status,error\\n';\n\nfunction csvEscape(v) {\n  const s = String(v == null ? '' : v);\n  return (s.includes(',') || s.includes('\"') || s.includes('\\n'))\n    ? '\"' + s.replace(/\"/g, '\"\"') + '\"'\n    : s;\n}\n\nconst out = [];\nfor (const item of $input.all()) {\n  const j = item.json;\n  const logPath = path.join(j.jobDir, 'results.log.csv');\n\n  const tiktokStatus = j.post_url || '';\n  const youtubeId    = (j.id) || (j.body && j.body.id) || '';\n  const youtubeStatus = j.youtube_error ? 'failed' : (youtubeId ? 'uploaded' : 'unknown');\n  const errors = [j.tiktok_error, j.youtube_error].filter(Boolean).join(' | ');\n\n  const row = [\n    new Date().toISOString(),\n    j.filename || path.basename(j.export_path || ''),\n    j.title || '',\n    j.post_id || '',\n    tiktokStatus,\n    youtubeId,\n    youtubeStatus,\n    errors\n  ].map(csvEscape).join(',') + '\\n';\n\n  if (!fs.existsSync(logPath)) fs.writeFileSync(logPath, HEADER);\n  fs.appendFileSync(logPath, row);\n\n  if (errors) {\n    try {\n      const token = process.env.TELEGRAM_BOT_TOKEN;\n      const chatId = process.env.TELEGRAM_CHAT_ID;\n      if (token && chatId) {\n        await this.helpers.httpRequest({\n          method: 'POST',\n          url: `https://api.telegram.org/bot${token}/sendMessage`,\n          json: true,\n          body: {\n            chat_id: chatId,\n            text: `Reelsmith publish FAILED\\nfile: ${j.filename || j.export_path}\\nerror: ${errors}`\n          }\n        });\n      }\n    } catch (_) { /* swallow alert errors */ }\n  }\n\n  out.push({ json: { ...j, logged: true } });\n}\nreturn out;"
       },
       "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
       "name": "Log Results",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2050, 300]
+      "position": [
+        2050,
+        300
+      ]
     },
     {
       "parameters": {
         "language": "javaScript",
-        "jsCode": "const fs = require('fs');\nconst path = require('path');\n\nconst items = $input.all();\nconst out = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const j = items[i].json;\n  // Archive on last item only — one manifest per execution\n  if (i === items.length - 1) {\n    const src = j.manifestPath;\n    if (src && fs.existsSync(src)) {\n      const processedDir = path.join(j.jobDir, 'processed');\n      fs.mkdirSync(processedDir, { recursive: true });\n      const stamp = new Date().toISOString().replace(/[:.]/g, '-');\n      const dest = path.join(processedDir, `manifest-${stamp}.csv`);\n      fs.renameSync(src, dest);\n      out.push({ json: { ...j, archived_to: dest } });\n      continue;\n    }\n  }\n  out.push({ json: j });\n}\nreturn out;"
+        "jsCode": "const fs = require('fs');\nconst path = require('path');\n\nconst items = $input.all();\nconst out = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const j = items[i].json;\n  // Archive on last item only \u2014 one manifest per execution\n  if (i === items.length - 1) {\n    const src = j.manifestPath;\n    if (src && fs.existsSync(src)) {\n      const processedDir = path.join(j.jobDir, 'processed');\n      fs.mkdirSync(processedDir, { recursive: true });\n      const stamp = new Date().toISOString().replace(/[:.]/g, '-');\n      const dest = path.join(processedDir, `manifest-${stamp}.csv`);\n      fs.renameSync(src, dest);\n      out.push({ json: { ...j, archived_to: dest } });\n      continue;\n    }\n  }\n  out.push({ json: j });\n}\nreturn out;"
       },
       "id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
       "name": "Archive Manifest",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2250, 300]
+      "position": [
+        2250,
+        300
+      ]
     },
     {
       "parameters": {
         "rule": {
-          "interval": [{ "field": "cronExpression", "expression": "*/5 * * * *" }]
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 */8 * * *"
+            }
+          ]
         }
       },
       "id": "f0f0f0f0-f0f0-4f0f-8f0f-f0f0f0f0f0f0",
       "name": "Scanner Trigger",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1,
-      "position": [250, 500]
+      "position": [
+        250,
+        500
+      ],
+      "notesInFlow": true,
+      "notes": "Layer-1 ToS coarse poll: every 8h. Layer-2 cap (<=3/day) lives in 'TikTok Rate Limit' Code node."
     },
     {
       "parameters": {
@@ -242,59 +261,246 @@
       "name": "Scan Manifests",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [450, 500]
+      "position": [
+        450,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "language": "javaScript",
+        "jsCode": "// Layer-2 ToS-mitigation rate cap. The Scanner Trigger cron (Layer-1) is\n// every 8h; this code enforces the actual <=3 posts/day cap by counting\n// successful TikTok dispatches in workflow static data, keyed by UTC date.\nconst today = new Date().toISOString().slice(0, 10);\nconst sd = $getWorkflowStaticData('global');\nif (sd.postsDate !== today) {\n  sd.postsDate = today;\n  sd.postsToday = 0;\n}\nif ((sd.postsToday || 0) >= 3) {\n  // Skip this branch \u2014 daily cap hit. Return empty array so downstream stops.\n  return [];\n}\nsd.postsToday = (sd.postsToday || 0) + 1;\n// Pass-through; the increment is best-effort optimistic (decremented on failure\n// would require a follow-up node \u2014 deferred).\nreturn $input.all();"
+      },
+      "id": "99aabbcc-1111-4111-8111-111111111111",
+      "name": "TikTok Rate Limit",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1230,
+        180
+      ],
+      "notesInFlow": true,
+      "notes": "Layer-2 ToS cap: <=3 posts/day, UTC-day-scoped via workflow static data. Layer-1 is the Scanner Trigger cron (0 */8 * * *)."
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://tiktok-sidecar.n8n-live.svc.cluster.local:8000/api/upload",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "parameterType": "formBinaryData",
+              "name": "video",
+              "inputDataFieldName": "clipBinary"
+            },
+            {
+              "name": "caption",
+              "value": "={{ ($json.title || '').substring(0, 150) }}"
+            },
+            {
+              "name": "hashtags",
+              "value": "={{ ($json.hashtags || []).join(' ') }}"
+            },
+            {
+              "name": "account",
+              "value": "reelsmith"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 300000,
+          "redirect": {
+            "redirect": {}
+          },
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "id": "99aabbcc-2222-4222-8222-222222222222",
+      "name": "TikTok Sidecar Upload",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1450,
+        180
+      ],
+      "notesInFlow": true,
+      "notes": "POSTs the clip + caption + hashtags to the in-cluster FastAPI sidecar (wraps makiisthenes/TiktokAutoUploader, cookie-auth). Replaces the 3 deleted TikTok Open API nodes (Init/Upload/Poll). Service URL: tiktok-sidecar.n8n-live.svc.cluster.local:8000"
     }
   ],
   "connections": {
     "Local File Trigger": {
-      "main": [[{ "node": "Index Clips", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Index Clips",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Index Clips": {
-      "main": [[{ "node": "Assign Peak Window", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Assign Peak Window",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Assign Peak Window": {
-      "main": [[{ "node": "Wait", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Wait",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Wait": {
-      "main": [[{ "node": "Read Clip File", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Read Clip File",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Read Clip File": {
-      "main": [[
-        { "node": "TikTok Init",   "type": "main", "index": 0 },
-        { "node": "YouTube Init",  "type": "main", "index": 0 }
-      ]]
-    },
-    "TikTok Init": {
-      "main": [[{ "node": "TikTok Upload", "type": "main", "index": 0 }]]
-    },
-    "TikTok Upload": {
-      "main": [[{ "node": "TikTok Poll Status", "type": "main", "index": 0 }]]
-    },
-    "TikTok Poll Status": {
-      "main": [[{ "node": "Merge Results", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "TikTok Rate Limit",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "YouTube Init",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "YouTube Init": {
-      "main": [[{ "node": "YouTube Capture Session", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "YouTube Capture Session",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "YouTube Capture Session": {
-      "main": [[{ "node": "YouTube Upload", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "YouTube Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "YouTube Upload": {
-      "main": [[{ "node": "Merge Results", "type": "main", "index": 1 }]]
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
     },
     "Merge Results": {
-      "main": [[{ "node": "Log Results", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Log Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Log Results": {
-      "main": [[{ "node": "Archive Manifest", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Archive Manifest",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Scanner Trigger": {
-      "main": [[{ "node": "Scan Manifests", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Scan Manifests",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     },
     "Scan Manifests": {
-      "main": [[{ "node": "Index Clips", "type": "main", "index": 0 }]]
+      "main": [
+        [
+          {
+            "node": "Index Clips",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TikTok Rate Limit": {
+      "main": [
+        [
+          {
+            "node": "TikTok Sidecar Upload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TikTok Sidecar Upload": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "pinData": {},
-  "tags": [{ "name": "reelsmith" }, { "name": "social-publish" }]
+  "tags": [
+    {
+      "name": "reelsmith"
+    },
+    {
+      "name": "social-publish"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- New tiktok-sidecar Deployment + Service + PVC in n8n-live namespace (replaces gated TikTok Open API path)
- Workflow JSON: 3 TikTok nodes removed, 2 added (rate-limit Code node + multipart HTTP Request to in-cluster Service)
- Image already at localhost:32000/reelsmith/tiktok-sidecar:0.1.0 (B-1 checkpoint present)
- Phase A validated end-to-end locally (real upload to TikTok succeeded; post manually deleted)

## Plan

~/.claude/plans/i-have-found-an-moonlit-parnas.md

## Test plan

- [ ] ArgoCD picks up new manifests, syncs to Healthy
- [ ] Pod tiktok-sidecar Running 1/1 in n8n-live ns
- [ ] Cluster-internal probe from inside n8n pod: wget http://tiktok-sidecar.n8n-live.svc.cluster.local:8000/healthz returns 200
- [ ] Operator runs cookie bootstrap (scp + kubectl create secret + rollout restart)
- [ ] Workflow re-imported in n8n UI (only TikTok Sidecar Upload node remains)
- [ ] Drive a real video through ReelSmith -> Syncthing -> n8n -> sidecar; verify live PUBLIC post URL

## Note

This PR does NOT touch the now-orphaned external-secret-tiktok.yaml. Cleanup deferred to a follow-up PR to keep blast radius small.