### PR TITLE
feat(backup): GC finished n8n backup Job pods (ttl 24h) + history 3->2

### DIFF
--- a/helm/n8n-application/templates/backup-cronjob.yaml
+++ b/helm/n8n-application/templates/backup-cronjob.yaml
@@ -9,10 +9,15 @@ metadata:
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit | default 2 }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit | default 2 }}
   jobTemplate:
     spec:
+      # GC finished backup Job pods so they don't linger (history limits alone
+      # keep up to N stale pods until the Nth-next run). 24h is well ABOVE the
+      # N8nBackupFailed alert window (for: 0m), so a FAILED backup Job persists
+      # long enough for kube-state-metrics + Prometheus to observe it before GC.
+      ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished | default 86400 }}
       backoffLimit: 2
       activeDeadlineSeconds: 600
       template:

--- a/helm/n8n-application/values-live.yaml
+++ b/helm/n8n-application/values-live.yaml
@@ -210,8 +210,14 @@ externalSecrets:
 backup:
   enabled: true
   schedule: "0 2 * * *"  # Daily at 2 AM
-  retention: 30  # days
+  retention: 30  # days  (dump-file retention via `find -mtime`; UNAFFECTED by the GC knobs below)
   storageSize: 10Gi
+  # Job/pod GC (objects + logs only — NOT the dump files, which the script prunes
+  # at `retention` days + the off-cluster rclone copy). ttl is well above the
+  # N8nBackupFailed alert window (for: 0m) so failed Jobs are still observed.
+  ttlSecondsAfterFinished: 86400  # delete finished backup Job pods after 24h
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
   # GAP-007: Off-cluster backup via rclone to S3-compatible target.
   # Prerequisites before enabling:
   #   1. Populate Vault: vault kv put kv/secret/n8n/live/backup-offcluster \


### PR DESCRIPTION
Part **B** of the hardening plan. Adds `ttlSecondsAfterFinished: 86400` to the `n8n-application-db-backup` CronJob jobTemplate and tightens `successful/failedJobsHistoryLimit` 3→2 so finished backup Job pods don't linger.

**Safety (critique #7/#11):** 24h ttl is far above the `N8nBackupFailed` alert's window (`for: 0m` on `kube_job_status_failed`), so a FAILED backup Job persists long enough for KSM+Prometheus to observe it before GC — no alert regression. **Dump-file retention is unaffected** (30d via `find -mtime` + off-cluster rclone copy); only Job/pod objects + logs are GC'd.

Validated: lint ✓, render shows `ttlSecondsAfterFinished: 86400` + history 2/2 ✓, server dry-run ✓. n8n-live is manual-sync → will sync in the agreed window and verify the fields land + a short-ttl throwaway Job GCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)