### PR TITLE
feat(reelsmith): atomic claim store + success-based publish watchdog

### DIFF
--- a/projects/reelsmith-social-publish/manifests/reelsmith-watchdog-cronjob.yaml
+++ b/projects/reelsmith-social-publish/manifests/reelsmith-watchdog-cronjob.yaml
@@ -1,0 +1,93 @@
+# Success-based watchdog for the Reelsmith Social Publish workflow.
+#
+# WHY: the original outage was 18/18 silent failures — "an execution ran" stayed
+# green the whole time. This watchdog reads execution_entity directly (independent
+# of n8n's own health) and alerts only on the signal that matters: finished runs
+# in the window with ZERO success and >=1 hard failure.
+#
+# Self-silencing by design:
+#  - host powered off (this cluster reboots often) or workflow deactivated => no
+#    new executions => the 25h window is empty => failed=0,ok=0 => no alert.
+#  - a healthy run sitting in a multi-day Wait has status 'waiting' (not error,
+#    not success) => failed=0 => no alert.
+#  - It does NOT catch a single dropped clip inside an otherwise-OK run — that's
+#    what scripts/unpublished-inventory.js is for. This catches systemic stalls.
+#
+# Secrets (NEVER in git):
+#  - reelsmith-watchdog-db / password  -> read-only role n8n_watchdog (SELECT on
+#    execution_entity only). Created out-of-band, re-create with:
+#      PW=$(openssl rand -hex 24)
+#      kubectl exec -i -n n8n-live <pg-pod> -c postgres -- psql -U postgres -d n8n \
+#        -c "DO \$do\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='n8n_watchdog') THEN CREATE ROLE n8n_watchdog LOGIN; END IF; END \$do\$;" \
+#        -c "ALTER ROLE n8n_watchdog LOGIN PASSWORD '$PW';" \
+#        -c "GRANT CONNECT ON DATABASE n8n TO n8n_watchdog; GRANT USAGE ON SCHEMA public TO n8n_watchdog; GRANT SELECT ON execution_entity TO n8n_watchdog;"
+#      kubectl create secret generic reelsmith-watchdog-db -n n8n-live --from-literal=password="$PW"
+#    ponytail: a direct k8s Secret, not ESO/Vault-managed like the others here.
+#      Trivially re-creatable read-only cred; promote to an ExternalSecret if it
+#      ever needs to survive a namespace rebuild unattended.
+#  - reelsmith-telegram / bot_token, chat_id  -> existing ESO-synced alert creds.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reelsmith-publish-watchdog
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: reelsmith-social-publish
+    app.kubernetes.io/component: reelsmith-watchdog
+spec:
+  # 30 min after each publish tick (publish cron is `0 */8 * * *`) => at most one
+  # alert per failed publish cycle, no extra dedup state needed.
+  schedule: "30 0,8,16 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 200   # don't fire a stale missed run after a host-off
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            # UNIQUE label: matches no egress policy => open egress (Telegram),
+            # and is the source the reelsmith-watchdog-to-postgres policy allows.
+            app.kubernetes.io/component: reelsmith-watchdog
+            app.kubernetes.io/part-of: reelsmith-social-publish
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: watchdog
+              image: postgres:16-alpine   # ships psql; curl added at start (open egress)
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef: { name: reelsmith-watchdog-db, key: password }
+                - name: TG_TOKEN
+                  valueFrom:
+                    secretKeyRef: { name: reelsmith-telegram, key: bot_token }
+                - name: TG_CHAT
+                  valueFrom:
+                    secretKeyRef: { name: reelsmith-telegram, key: chat_id }
+                - name: WF_ID
+                  value: "SKLkX5qUDYLlWTxo"
+              command: ["/bin/sh", "-eu", "-c"]
+              args:
+                - |
+                  apk add --no-cache curl >/dev/null 2>&1 || { echo "FATAL: apk add curl failed (egress to alpine CDN?)"; exit 1; }
+                  RES=$(psql -h postgres-service -U n8n_watchdog -d n8n -tA -c \
+                    "SELECT count(*) FILTER (WHERE status IN ('error','crashed'))||'|'||count(*) FILTER (WHERE status='success') \
+                     FROM execution_entity WHERE \"workflowId\"='$WF_ID' AND \"startedAt\" > now() - interval '25 hours';")
+                  FAILED=${RES%%|*}; OK=${RES##*|}
+                  echo "window=25h failed=$FAILED ok=$OK"
+                  if [ "${FAILED:-0}" -ge 1 ] && [ "${OK:-0}" -eq 0 ]; then
+                    MSG="⚠️ Reelsmith publisher stalled: ${FAILED} failed execution(s) and 0 success in the last 25h (n8n workflow $WF_ID). Check the n8n executions list."
+                    # token stays out of argv: curl reads url+data from a -K config on stdin
+                    printf 'url = "https://api.telegram.org/bot%s/sendMessage"\ndata-urlencode = "chat_id=%s"\ndata-urlencode = "text=%s"\n' \
+                      "$TG_TOKEN" "$TG_CHAT" "$MSG" \
+                      | curl -sS -K - >/dev/null && echo "ALERT sent" || { echo "FATAL: telegram send failed"; exit 1; }
+                  else
+                    echo "ok: no alert"
+                  fi
+              resources:
+                requests: { cpu: 50m, memory: 64Mi }   # namespace LimitRange min cpu = 50m
+                limits: { cpu: 200m, memory: 128Mi }

--- a/projects/reelsmith-social-publish/manifests/reelsmith-watchdog-networkpolicy.yaml
+++ b/projects/reelsmith-social-publish/manifests/reelsmith-watchdog-networkpolicy.yaml
@@ -1,0 +1,29 @@
+# Additive ingress: let the publish-watchdog CronJob reach Postgres on 5432.
+# The helm-managed `n8n-application-postgres` policy only admits component
+# n8n/worker/backup. We do NOT edit that (helm would revert it) — NetworkPolicies
+# are additive, so this extra policy unions in the watchdog -> postgres path.
+# The watchdog pod carries a UNIQUE component label so it is NOT selected by the
+# worker/n8n EGRESS policies and therefore keeps unrestricted egress (needs to
+# reach api.telegram.org). Verified 2026-06-20: a pod with non-allowed labels
+# times out to postgres-service:5432 — this policy is what closes that gap.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reelsmith-watchdog-to-postgres
+  namespace: n8n-live
+  labels:
+    app.kubernetes.io/part-of: reelsmith-social-publish
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: reelsmith-watchdog
+      ports:
+        - port: 5432
+          protocol: TCP

--- a/projects/reelsmith-social-publish/scripts/assign-peak-window.jsCode.js
+++ b/projects/reelsmith-social-publish/scripts/assign-peak-window.jsCode.js
@@ -1,0 +1,88 @@
+
+const fs = require('fs');
+const path = require('path');
+
+const REGIONS = [
+  { tz: 'Africa/Johannesburg', hours: [12, 18, 20] },
+  { tz: 'America/New_York',    hours: [12, 18, 20] },
+  { tz: 'America/Los_Angeles', hours: [12, 18, 20] },
+  { tz: 'Europe/London',       hours: [12, 19, 21] }
+];
+const MIN_LEAD_MIN = 10;
+const DEDUP_MIN = 30;
+
+const now = DateTime.utc();
+const raw = [];
+
+for (let day = 0; day < 7; day++) {
+  for (const r of REGIONS) {
+    for (const h of r.hours) {
+      const utc = DateTime.now().setZone(r.tz)
+        .startOf('day').plus({ days: day, hours: h }).toUTC();
+      if (utc.diff(now, 'minutes').minutes >= MIN_LEAD_MIN) {
+        raw.push(utc);
+      }
+    }
+  }
+}
+
+raw.sort((a, b) => a.toMillis() - b.toMillis());
+
+const windows = [];
+for (const w of raw) {
+  const last = windows[windows.length - 1];
+  if (!last || w.diff(last, 'minutes').minutes >= DEDUP_MIN) {
+    windows.push(w);
+  }
+}
+
+if (windows.length === 0) {
+  throw new Error('No peak windows available in 7-day lookahead');
+}
+
+// --- Atomic claim store: closes the 8h-rescan double-post race ----------------
+// The next Scanner Trigger re-indexes the SAME un-archived manifest while clips
+// are mid-Wait (no ledger row yet) -> would re-schedule + double-post. An fs
+// O_EXCL marker on the shared hostpath PVC is atomic across both workers
+// (verified: a 2nd `wx` write -> EEXIST on the live mount). The marker is keyed
+// on `filename` (the same column the results ledger + unpublished-inventory.js
+// use), so a re-indexed clip that is in-flight OR already posted hits EEXIST and
+// is skipped. No external require() -- `fs`/`path` are the only allowlisted
+// builtins (avoids the luxon-style sandbox abort that caused this outage).
+//
+// ponytail: marker is NEVER released on success -> a clip that exhausts the
+//   in-execution upload retries stays claimed. Safe direction (blocks a double
+//   post, not a missed retry; the watchdog + unpublished-inventory.js surface
+//   drops). Recover a genuinely stuck clip: run unpublished-inventory.js, then
+//   `rm <jobDir>/.claims/<filename>.json`. Atomicity assumes single-node local
+//   fs; on multi-node/NFS, O_EXCL is not atomic -> move to a Postgres UNIQUE claim.
+const execId = (typeof $execution !== 'undefined' && $execution && $execution.id) ? $execution.id : 'na';
+const out = [];
+for (const item of $input.all()) {
+  const filename = item.json.filename;
+  const jobDir = item.json.jobDir;
+  if (!filename || !jobDir) {
+    throw new Error('Claim store: item missing filename/jobDir: ' + JSON.stringify(item.json).slice(0, 200));
+  }
+  const claimDir = path.join(jobDir, '.claims');
+  fs.mkdirSync(claimDir, { recursive: true });
+  const marker = path.join(claimDir, path.basename(String(filename)) + '.json');
+  try {
+    fs.writeFileSync(
+      marker,
+      JSON.stringify({ claimedAt: now.toISO(), execId, clipIndex: item.json.clipIndex }),
+      { flag: 'wx' }   // O_EXCL: throws EEXIST if the clip is already claimed
+    );
+  } catch (e) {
+    if (e && e.code === 'EEXIST') continue;   // already claimed (in-flight or posted) -> skip
+    throw e;
+  }
+  out.push({
+    json: {
+      ...item.json,
+      scheduledAt: windows[item.json.clipIndex % windows.length].toISO()
+    }
+  });
+}
+
+return out;

--- a/projects/reelsmith-social-publish/scripts/claim-store.selfcheck.js
+++ b/projects/reelsmith-social-publish/scripts/claim-store.selfcheck.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+// Falsifiable check of the claim-store gate logic (the same O_EXCL pattern the
+// Assign Peak Window node uses). Proves: 1st pass claims all clips, a concurrent
+// 2nd pass over the same clips claims ZERO (EEXIST -> skip). No n8n required.
+//   node claim-store.selfcheck.js   ->  exits 0 on pass, 1 on fail.
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function claimPass(items, root) {
+  const out = [];
+  for (const it of items) {
+    const claimDir = path.join(root, it.jobDir, '.claims');
+    fs.mkdirSync(claimDir, { recursive: true });
+    const marker = path.join(claimDir, path.basename(it.filename) + '.json');
+    try {
+      fs.writeFileSync(marker, JSON.stringify({ clipIndex: it.clipIndex }), { flag: 'wx' });
+    } catch (e) {
+      if (e && e.code === 'EEXIST') continue;
+      throw e;
+    }
+    out.push(it);
+  }
+  return out;
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claimtest-'));
+const items = [
+  { jobDir: 'job-a', filename: '00_clip.mp4', clipIndex: 0 },
+  { jobDir: 'job-a', filename: '01_clip.mp4', clipIndex: 1 },
+  { jobDir: 'job-b', filename: '00_clip.mp4', clipIndex: 0 } // same basename, different job -> distinct
+];
+
+const first = claimPass(items, root);
+const second = claimPass(items, root); // simulates the 8h rescan over the same clips
+fs.rmSync(root, { recursive: true, force: true });
+
+const ok = first.length === 3 && second.length === 0;
+console.log(`first=${first.length} (want 3)  second=${second.length} (want 0)  =>  ${ok ? 'PASS' : 'FAIL'}`);
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Permanent hardening for the **Reelsmith Social Publish** workflow. Workflow remains **deactivated** throughout — nothing posts. Both items validated live against the cluster.

## 1. Atomic claim store — closes the 8h-rescan double-post race
The next `Scanner Trigger` re-indexes the same un-archived manifest while clips sit in the multi-day `Wait` (no ledger row yet) → would re-schedule and double-post. `Assign Peak Window` now writes an `fs` `O_EXCL` marker per clip (`<jobDir>/.claims/<filename>.json`) **before** the Wait; a concurrent rescan hits `EEXIST` and skips the clip (in-flight or already posted).

- Atomic on the shared hostpath PVC across both workers — **verified** (`2nd wx write → EEXIST` on the live mount).
- Keyed on `filename` to match the results ledger + `unpublished-inventory.js`.
- Only allowlisted `fs`/`path` builtins — **no external `require()`** (the bug class that caused the outage).
- `scripts/claim-store.selfcheck.js` asserts the gate (1st pass claims all, rescan claims zero). Applied to the live DB-stored workflow via API `PUT`; node read-back confirms the marker logic and `active=false`.
- `scripts/assign-peak-window.jsCode.js` is the canonical source for that node (the live workflow has no VCS).

**Ceiling (documented in code):** marker is never released on success, so a clip that exhausts in-execution upload retries stays claimed — *safe* direction (blocks a double-post, not a missed retry). Recover via `unpublished-inventory.js` + `rm` the marker. Single-node local-fs O_EXCL only; multi-node/NFS would need a Postgres UNIQUE claim.

## 2. Success-based watchdog — catches the stall that stayed "green" for 18/18 runs
A `CronJob` reads `execution_entity` **directly** (independent of n8n's own health) via a dedicated **read-only** role (`n8n_watchdog`, `SELECT` on `execution_entity` only). Alerts to Telegram **only** when a 25h window has ≥1 hard failure and **zero** success. Self-silences during host-off / deactivation / in-flight Waits.

- Additive `NetworkPolicy` grants just the watchdog label → `postgres:5432`; the pod's unique component label keeps egress open for Telegram (so it doesn't inherit the worker/n8n egress restrictions).
- **Verified:** a non-allowed pod times out to postgres (policy enforced); the watchdog path succeeds (`window=25h failed=0 ok=0 → no alert`); the Telegram token validates (`getMe ok`, `@reelsmith_bot`).
- DB password is a k8s Secret (`reelsmith-watchdog-db`), **never in git** (recreate command in the manifest header).

## Deploy
ArgoCD syncs `projects/reelsmith-social-publish/manifests` → adopts the already-applied CronJob + NetworkPolicy on merge (identical, no drift). The `n8n_watchdog` role + secret are already created in-cluster.

## Not in this PR (user gates)
- One live alert-send test (would post to the ops channel — opt-in).
- TikTok cookie refresh + canary go-ahead before reactivation/backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
